### PR TITLE
This should set the correct mime type

### DIFF
--- a/src/do.js
+++ b/src/do.js
@@ -34,6 +34,7 @@ const filesLoop = async (dir) => {
           Key: "covid-data" + dir.substr(TEMP_PATH.length) + "/" + file,
           Body: fs.readFileSync(fullPath),
           ACL: "public-read",
+          ContentType: "application/json",
         };
         // console.log("params :>> ", params);
         uploadObject(params);


### PR DESCRIPTION
Seemed to work well on the deep time script, so I figured why not for the COVID data.